### PR TITLE
Oboe egg from pypi.tracelytics.com is broken

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,12 +33,6 @@ How to install
 
 Update your ``buildout.cfg`` file:
 
-* Add tracelytics pypi under ``find-links``
-
-      ::
-
-        find-links += http://pypi.tracelytics.com/oboe
-
 * Add package in develop mode
 
       ::


### PR DESCRIPTION
Egg from http://pypi.tracelytics.com/oboe is broken, use the one from https://pypi.python.org/pypi
